### PR TITLE
🔧 fix: add unique index for user and name fields in Campaign schema

### DIFF
--- a/server/src/repository/messenger/Campaign.ts
+++ b/server/src/repository/messenger/Campaign.ts
@@ -40,6 +40,8 @@ const campaignSchema = new mongoose.Schema<ICampaign>(
 	{ timestamps: true }
 );
 
+campaignSchema.index({ user: 1, name: 1 }, { unique: true });
+
 const CampaignDB = mongoose.model<ICampaign>('Campaign', campaignSchema);
 
 export default CampaignDB;


### PR DESCRIPTION
The unique index ensures that there are no duplicate campaigns with the same user and name combination in the database.